### PR TITLE
Add smoke test: launch snap in VM and capture screenshot

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,4 +1,4 @@
-name: 🧪 Test snap can be built
+name: 🧪 Build and smoke test snap
 
 on:
   push:
@@ -7,8 +7,13 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
+    name: 🔨 Build snap
     runs-on: ubuntu-latest
 
     steps:
@@ -17,22 +22,100 @@ jobs:
 
       - name: Build snap
         uses: snapcore/action-build@v1
-        id: snapcraft
+        id: build
 
       - name: Show log on build failure
-        if: ${{ failure() }}
-        run: |
-          cat /home/runner/.local/state/snapcraft/log/snapcraft*.log
-          exit 1
+        if: failure()
+        run: cat /home/runner/.local/state/snapcraft/log/snapcraft*.log
 
       - name: Review snap
         uses: diddlesnaps/snapcraft-review-action@v1
         with:
-          snap: ${{ steps.snapcraft.outputs.snap }}
+          snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
 
-      - name: Upload artifacts
+      - name: Upload snap artifact
         uses: actions/upload-artifact@v4
         with:
           name: snap
-          path: ${{ steps.snapcraft.outputs.snap }}
+          path: ${{ steps.build.outputs.snap }}
+          retention-days: 7
+
+  smoke-test:
+    name: 💨 Smoke test (launch + screenshot)
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+
+      - name: Setup ghvmctl
+        run: |
+          sudo snap install ghvmctl
+          sudo snap connect ghvmctl:lxd lxd:lxd
+
+      - name: Prepare VM
+        run: ghvmctl prepare
+
+      - name: Install snap into VM
+        run: |
+          SNAP_FILE=$(ls *.snap | head -1)
+          VM_NAME=$(ghvmctl exec -- hostname | tr -d '[:space:]')
+          lxc file push "$SNAP_FILE" "local:$VM_NAME/home/ubuntu/$SNAP_FILE"
+          ghvmctl exec -- sudo snap install --dangerous "/home/ubuntu/$SNAP_FILE"
+
+      - name: Launch app and wait for it to render
+        run: |
+          ghvmctl snap-run mame.mame
+          sleep 30
+
+      - name: Take screenshots
+        run: |
+          ghvmctl screenshot-full
+          ghvmctl screenshot-window
+          ls -lh "$HOME/ghvmctl-screenshots/"
+
+      - name: Output app logs
+        if: always()
+        run: ghvmctl exec -- cat /home/ubuntu/mame.mame.log 2>/dev/null || true
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: smoke-test-screenshots
+          path: ~/ghvmctl-screenshots/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Comment on PR with screenshot link
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### 🧪 Smoke test ✅
+
+Snap launched in a VM. 📸 Download \`smoke-test-screenshots\` from the [run](${runUrl}) to view.`
+            });


### PR DESCRIPTION
Adds a second CI job that runs after a successful build:

1. Installs the built snap into a fresh LXD desktop VM (via [ghvmctl](https://github.com/snapcrafters/ghvmctl))
2. Launches `mame`
3. Waits 30 seconds for the app to render
4. Takes full-screen and window screenshots
5. Uploads them as the `smoke-test-screenshots` workflow artifact
6. Posts a comment on the PR linking to the run

This gives basic confidence that the snap at least launches without crashing on each PR/version bump. Same approach used by [snapcrafters/ci](https://github.com/snapcrafters/ci).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI smoke test that boots an LXD VM, installs the built snap, launches `mame`, waits for render, and captures screenshots. This verifies the snap launches and posts a PR comment linking to the run.

- **New Features**
  - Adds `smoke-test` job after build using `canonical/setup-lxd` and `ghvmctl`.
  - Installs the built snap in the VM, runs `mame.mame`, waits 30s, and captures full-screen and window screenshots.
  - Uploads `smoke-test-screenshots` artifact (14‑day retention) and comments on the PR with the Actions run link.

- **Refactors**
  - Renames build step id to `build` and updates references; updates workflow name.
  - Adds workflow `permissions` to allow PR comments (`contents: read`, `pull-requests: write`).
  - Sets snap artifact retention to 7 days and simplifies build failure log output.

<sup>Written for commit 9c42f048148eef6c67924d511acf6d1c8db95efd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

