### PR TITLE
Add smoke test: launch snap in VM and capture screenshot

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,4 +1,4 @@
-name: 🧪 Build and smoke test snap
+name: Build and smoke test snap
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    name: 🔨 Build snap
+    name: Build snap
     runs-on: ubuntu-latest
 
     steps:
@@ -42,7 +42,7 @@ jobs:
           retention-days: 7
 
   smoke-test:
-    name: 💨 Smoke test (launch + screenshot)
+    name: Smoke test (launch + screenshot)
     runs-on: ubuntu-latest
     needs: build
 
@@ -115,7 +115,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### 🧪 Smoke test ✅
-
-Snap launched in a VM. 📸 Download \`smoke-test-screenshots\` from the [run](${runUrl}) to view.`
+              body: `### Smoke test\n\nSnap launched in a VM. Screenshots available as the \`smoke-test-screenshots\` artifact on the [run](${runUrl}).`
             });

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # mamesnap
 
+[![mame](https://github.com/popey/mamesnap/actions/workflows/test-snap-can-build.yml/badge.svg)](https://github.com/popey/mamesnap/actions)
 [![mame](https://snapcraft.io/mame/badge.svg)](https://snapcraft.io/mame)
 [![mame](https://snapcraft.io/mame/trending.svg?name=0)](https://snapcraft.io/mame)
 
-Stable build of latest tagged release of MAME
+## MAME
+
+MAME is a multi-purpose emulation framework. Its purpose is to preserve decades of software history. As electronic technology continues to rush forward, MAME prevents this important vintage software from being lost and forgotten.
+
+This snap is a community-maintained unofficial build of [MAME](https://github.com/mamedev/mame).
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/mame)
+
+## Install
+
+Install on any [supported Linux](https://snapcraft.io/docs/installing-snapd) distribution:
+
+```
+snap install mame
+```
+


### PR DESCRIPTION
Adds a second CI job after a successful build that installs the snap into a fresh LXD desktop VM (via [ghvmctl](https://github.com/snapcrafters/ghvmctl)), launches `mame`, waits 30s, takes screenshots and uploads them as workflow artifacts.

Same approach used by [snapcrafters/ci](https://github.com/snapcrafters/ci).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI smoke test that launches the built snap in a fresh LXD VM, captures screenshots, and uploads them as artifacts. Also removes emoji to avoid UTF-8 issues and updates the README with a CI badge and install instructions.

- **New Features**
  - Adds smoke-test job: spin up LXD desktop VM via `ghvmctl`, install snap, launch `mame`, wait 30s, take screenshots.
  - Uploads screenshots as `smoke-test-screenshots` and comments on the PR with a link to the run.

- **Bug Fixes**
  - Remove emojis from workflow names and comments to fix UTF-8 encoding issues.
  - Minor YAML cleanup.

<sup>Written for commit c086bc2cfe5d98c9803bc6a49c10e1c59f14f8bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

