### PR TITLE
Fix MAME 0.288 build with Qt 6

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,7 +122,7 @@ parts:
     source-type: git
     #make-parameters:  [CFLAGS="-fpch-preprocess", CXXFLAGS="-fpch-preprocess", CC="gcc-10", CXX="g++-10"]
     override-build: |
-      export QT_SELECT="5"
+      export QT_SELECT="6"
       export CFLAGS+="-fpch-preprocess"
       export CXXFLAGS+="-fpch-preprocess"
       make NOWERROR='1' OPTIMIZE='2' TOOLS='1' -j$((`nproc`+1))
@@ -136,8 +136,8 @@ parts:
       - libjpeg-dev
       - libpugixml-dev
       - libportmidi-dev
-      - qtdeclarative5-dev
-      - qtbase5-dev
+      - qt6-base-dev
+      - qt6-base-dev-tools
       - libsdl2-ttf-dev
       - libsdl2-dev
       - libutf8proc-dev
@@ -147,7 +147,7 @@ parts:
       - python3-dev
       - rapidjson-dev
       - zlib1g-dev
-      - libqt5core5a
+      - libqt6core6
       - libasio-dev
       - libglm-dev
     stage-packages:
@@ -196,9 +196,11 @@ parts:
       - zlib1g
       - libdouble-conversion3
       - libpcre2-16-0
-      - libqt5core5a
-      - libqt5gui5
-      - libqt5widgets5
+      - libqt6core6
+      - libqt6dbus6
+      - libqt6gui6
+      - libqt6network6
+      - libqt6widgets6
 
   graphics-core22:
     after: [mame]


### PR DESCRIPTION
## Summary
- switch the MAME build from Qt 5 packages to Qt 6 packages
- export `QT_SELECT=6` during the build
- stage the Qt 6 runtime libraries needed by the packaged app

## Verification
- latest failing Actions run dies with `qmake6: not found`
- local `snapcraft --use-lxd` completed successfully and produced `mame_mame0288_amd64.snap` on 2026-05-29 17:35 UTC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the MAME 0.288 Snap build to Qt 6 to fix build failures and include the correct runtime libraries. Resolves the “qmake6: not found” error by using the Qt 6 toolchain.

- **Bug Fixes**
  - Export `QT_SELECT=6` during build.
  - Replace Qt 5 dev packages with `qt6-base-dev` and `qt6-base-dev-tools` (provides `qmake6`).
  - Update build deps from `libqt5core5a` to `libqt6core6`.
  - Stage Qt 6 runtime libs: `libqt6core6`, `libqt6dbus6`, `libqt6gui6`, `libqt6network6`, `libqt6widgets6`.

<sup>Written for commit 30834ff3cbc4db8b1fd6e4ed7b020cfd97ebc392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/mamesnap/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

